### PR TITLE
Added symlink migration mode feature

### DIFF
--- a/docs/drs.rst
+++ b/docs/drs.rst
@@ -106,7 +106,7 @@ List Unix command to apply
 
 .. warning:: At this step, no file are moved or copy to the finale DRS.
 
-.. note:: ``esgprep drs`` allows different file migration mode. Default is to move the files from the incomping path to the finale DRS. Use ``--copy`` to make hard copies or ``--link`` to make hard links from the incoming path. We recommend to use ``--link`` and remove the incoming directory after DRS checking. This doesn't affect the symbolic link skeleton used for the dataset versioning.
+.. note:: ``esgprep drs`` allows different file migration mode. Default is to move the files from the incomping path to the finale DRS. Use ``--copy`` to make hard copies, ``--link`` to make hard links or ``--symlink`` to make symbolic links from the incoming path. We recommend to use ``--link`` and remove the incoming directory after DRS checking. This doesn't affect the symbolic link skeleton used for the dataset versioning.
 
 Run the DRS upgrade
 *******************

--- a/esgprep/drs/handler.py
+++ b/esgprep/drs/handler.py
@@ -9,6 +9,7 @@
 
 import logging
 import os
+import re
 from collections import OrderedDict
 from datetime import datetime
 
@@ -25,7 +26,6 @@ from esgprep.drs.constants import *
 from esgprep.drs.exceptions import *
 from esgprep.utils.constants import *
 from esgprep.utils.exceptions import *
-
 
 class File(object):
     """

--- a/esgprep/drs/main.py
+++ b/esgprep/drs/main.py
@@ -49,6 +49,8 @@ class ProcessingContext(object):
             self.mode = 'copy'
         elif args.link:
             self.mode = 'link'
+        elif args.symlink:
+            self.mode = 'symlink'
         else:
             self.mode = 'move'
         self.version = args.version

--- a/esgprep/esgprep.py
+++ b/esgprep/esgprep.py
@@ -371,6 +371,11 @@ def get_args():
         action='store_true',
         default=False,
         help="""Hard link incoming files to the DRS tree. Default is moving files.""")
+    group.add_argument(
+        '--symlink',
+        action='store_true',
+        default=False,
+        help="""Symbolic link incoming files to the DRS tree. Default is moving files.""")
     drs.add_argument(
         '--filter',
         metavar='"*.nc"',


### PR DESCRIPTION
The `--symlink` migration mode option to `drs` subcommand has been created. 

The `docs` has been modified to reflect this new feature.

P.S.: The `import re` commit it's minor change
