### PR TITLE
Changes related to --commands-file

### DIFF
--- a/esgprep/esgprep.py
+++ b/esgprep/esgprep.py
@@ -272,6 +272,11 @@ def get_args():
         metavar='TXT_FILE',
         type=str,
         help=COMMANDS_FILE_HELP)
+    drs.add_argument(
+        '--overwrite-commands-file',
+        action='store_true',
+        default=False,
+        help=OVERWRITE_COMMANDS_FILE_HELP)
     group = drs.add_mutually_exclusive_group(required=False)
     group.add_argument(
         '--copy',

--- a/esgprep/utils/constants.py
+++ b/esgprep/utils/constants.py
@@ -354,6 +354,12 @@ COMMANDS_FILE_HELP = \
 
     """
 
+OVERWRITE_COMMANDS_FILE_HELP = \
+    """
+    Allow overwriting of existing file specified by "--commands-file".
+
+    """
+
 RESCAN_HELP = \
     """
     Force incoming files rescan.|n


### PR DESCRIPTION
* Changed all calls to print_cmd to use mode append (removed positional 'mode'
  argument, and added keyword argument with a default value of 'a', which is
  never overridden).  This is because "upgrade" is called once per data file,
  so the commands file was being overwritten each time (in the call with the
  mode="w"), so it only contained the commands for the last data file.

* As a consequence of the change described above, it is necessary to deal with
  the case of an already existing commands file.  So support for another
  command-line option, "--overwrite-commands-file", is added.  If the file
  exists and this option is set, delete the file.  If the file exists and this
  is not set, exit with an error (and return status 1).

* Renamed internal variable "printf" to "commands_file". The name "printf"
  suggests that it relates to the "printf" string formatting in the C library
  (see "man 3 printf"), which is confusing.

* In ProcessingContext.__init__ , changed logging.warning to print (I can't
  see any messages produced by logging.warning - is the logger initialised
  yet?)