### PR TITLE
when max_threads=1, do not create a thread pool

### DIFF
--- a/esgprep/drs/context.py
+++ b/esgprep/drs/context.py
@@ -48,6 +48,7 @@ class ProcessingContext(object):
         if args.set_key:
             self.set_keys = dict(args.set_key)
         self.threads = args.max_threads
+        self.use_pool = (self.threads > 1)
         self.project = args.project
         self.action = args.action
         if args.copy:
@@ -108,7 +109,8 @@ class ProcessingContext(object):
         # And exclude hidden files
         self.sources.FileFilter[uuid()] = ('^\..*$', True)
         # Init threads pool
-        self.pool = ThreadPool(int(self.threads))
+        if self.use_pool:
+            self.pool = ThreadPool(int(self.threads))
         return self
 
     def _check_existing_commands_file(self):
@@ -126,8 +128,9 @@ class ProcessingContext(object):
                 
     def __exit__(self, *exc):
         # Close threads pool
-        self.pool.close()
-        self.pool.join()
+        if self.use_pool:
+            self.pool.close()
+            self.pool.join()
         # Decline outputs depending on the scan results
         # Raise errors when one or several files have been skipped or failed
         # Default is sys.exit(0)

--- a/esgprep/drs/main.py
+++ b/esgprep/drs/main.py
@@ -8,6 +8,7 @@
 """
 
 import logging
+import itertools
 
 from ESGConfigParser.custom_exceptions import NoConfigOption
 
@@ -191,7 +192,10 @@ def run(args):
             logging.warning(msg)
         else:
             nfiles = len(ctx.sources)
-            processes = ctx.pool.imap(process, ctx.sources)
+            if ctx.use_pool:
+                processes = ctx.pool.imap(process, ctx.sources)
+            else:
+                processes = itertools.imap(process, ctx.sources)
             if ctx.pbar:
                 processes = as_pbar(processes, desc='Scanning incoming files', units='files', total=nfiles)
             # Process supplied files

--- a/esgprep/mapfile/context.py
+++ b/esgprep/mapfile/context.py
@@ -44,6 +44,7 @@ class ProcessingContext(object):
         self.notes_url = args.tech_notes_url
         self.no_version = args.no_version
         self.threads = args.max_threads
+        self.use_pool = (self.threads > 1)
         self.dataset = args.dataset
         if not args.no_cleanup:
             self.clean()
@@ -109,13 +110,15 @@ class ProcessingContext(object):
             # If --latest-symlink, --version is set to "latest"
             self.sources.PathFilter['version_filter'] = '/{}'.format(self.version)
         # Init threads pool
-        self.pool = ThreadPool(int(self.threads))
+        if self.use_pool:
+            self.pool = ThreadPool(int(self.threads))
         return self
 
     def __exit__(self, *exc):
         # Close threads pool
-        self.pool.close()
-        self.pool.join()
+        if self.use_pool:
+            self.pool.close()
+            self.pool.join()
         # Decline outputs depending on the scan results
         # Raise errors when one or several files have been skipped or failed
         # Default is sys.exit(0)

--- a/esgprep/mapfile/main.py
+++ b/esgprep/mapfile/main.py
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 from datetime import datetime
+import itertools
 
 from ESGConfigParser import interpolate
 from lockfile import LockFile
@@ -186,7 +187,10 @@ def run(args):
     with ProcessingContext(args) as ctx:
         logging.info('==> Scan started')
         nfiles = len(ctx.sources)
-        processes = ctx.pool.imap(process, ctx.sources)
+        if ctx.use_pool:
+            processes = ctx.pool.imap(process, ctx.sources)
+        else:
+            processes = itertools.imap(process, ctx.sources)
         if ctx.pbar:
             processes = as_pbar(processes, desc='Mapfile(s) generation', units='files', total=nfiles)
         # Process supplied files


### PR DESCRIPTION
@glevava 

As you know from our discussions on Slack, I found that during checksum calculation in `esgprep drs`, there were some threads deadlock problems. I understand that you are implementing use of `hashlib` for the checksums in place of running `sha256sum` via `os.Popen`, and *hopefully* this will be thread-safe. However, I have not succeeded in setting up a reliable test environment to be *sure* that it will solve all the problems, and I do not want some unpleasant surprise during CMIP6 operations.

I tried to investigate solving this by using processes in place of threads (that is, using `multiprocessing` in place of `multiprocessing.dummy`), but this would require the input to be able to be pickled, which seems very difficult to achieve, given the complexity of the `ProcessingContext` object.

So now I propose a simple "safety valve", just in case of any problems. Simply, if `--max-threads` is set to 1, then it will not create any pool, but it will instead use the simple `itertools.imap` for the processing, so then we can have good confidence that there will be no problems with interactions with the threading library (it will still be imported, but not used). It will be reassuring to have this option available, even if in the end we do not need it. In fact if it arises during operations that we need to set `--max-threads=1`, then we can easily compensate for the slower run time by processing more datasets simultaneously in the calling script.

I have tested `drs` and `mapfile` functions to check that the result with `--max-threads=1` is still the same as with more threads, and it seems to be (apart from possibly the ordering of the commands in drs or the order of the lines in the mapfiles).